### PR TITLE
Include team members w/ 0 commits in output

### DIFF
--- a/git_commit_analyzer/analyzer.py
+++ b/git_commit_analyzer/analyzer.py
@@ -25,6 +25,19 @@ def analyze_commits(commits, team=None, user_db=None):
         'lines_removed': 'sum'
     }).rename(columns={'commit_hash': 'commits'}).reset_index().rename(columns={'author_full': 'Author'})
 
+    if team:
+        team_users = {user["full_name"] for user in user_db["users"] if user.get("team", "").lower() == team.lower()}
+        for member in team_users:
+            if member not in summary['Author'].values:
+                summary = pd.concat([summary, pd.DataFrame([{
+                    'Author': member,
+                    'commits': 0,
+                    'lines_added': 0,
+                    'lines_removed': 0,
+                    '%_commits': 0.00,
+                    '%_lines_added': 0.00
+                }])], ignore_index=True)
+
     # Calculate percentages
     total_commits = summary['commits'].sum()
     total_lines_added = summary['lines_added'].sum()


### PR DESCRIPTION
When `--team` is included as an argument, every person on the team will be included. This is to highlight team members with zero commits in a repo so that they can be assigned tasks related to it and increase their familiarity,